### PR TITLE
Add delegate providers to support duplicate id names

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ A Java annotation processor that builds a ResourceProvider class which contains 
    public Drawable getAnyDrawable() { ... } 
    ```
    
+  Calling ResourceProvider APIS
+  =============================
+  In order to avoid conflicts with duplicate resource ids, ResourceProvider organizes its APIs into delegate providers for
+  each resource type.  To call a ResourceProvider API, clients will make a call in the format:
+  
+  ```java
+  resourceProvider.<resource_type>.<resource_name>
+  ```
+  
+  For example, to get a String resource:
+  ```java
+  resourceProvider.string.getSomeString()
+  ```
+   
+  And for a color
+  ```java
+  resourceProvider.color.getSomeColor()
+  ```
+   
   Setup
   ======================
   

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
     }
 
     group = 'com.xfinity'
-    version = '0.9.1'
+    version = '0.10'
 }
 
 ext {
@@ -24,6 +24,6 @@ ext {
     artifactPrefix = 'resourceprovider'
     groupId = 'com.xfinity'
     uploadName = 'Resource-Provider'
-    publishVersion = '0.9.1'
+    publishVersion = '0.10'
     description = 'First cut at a generated resource provider abstraction'
 }

--- a/compiler/src/main/java/com/xfinity/resourceprovider/RpProcessor.java
+++ b/compiler/src/main/java/com/xfinity/resourceprovider/RpProcessor.java
@@ -142,11 +142,32 @@ public class RpProcessor extends AbstractProcessor {
                               List<String> rColorVars)
             throws UnnamedPackageException, IOException {
         String packageName = getPackageName(processingEnv.getElementUtils(), annotatedClass);
-        RpCodeGenerator codeGenerator = new RpCodeGenerator(rStringVars, rPluralVars, rDrawableVars, rDimenVars,
+        RpCodeGenerator codeGenerator = new RpCodeGenerator(packageName, rStringVars, rPluralVars, rDrawableVars, rDimenVars,
                                                             rIntegerVars, rColorVars);
-        TypeSpec generatedClass = codeGenerator.generateClass();
-        JavaFile javaFile = builder(packageName, generatedClass).build();
-        javaFile.writeTo(processingEnv.getFiler());
+
+        TypeSpec stringProviderClass = codeGenerator.generateStringProviderClass();
+        JavaFile stringProviderJavaFile = builder(packageName, stringProviderClass).build();
+        stringProviderJavaFile.writeTo(processingEnv.getFiler());
+
+        TypeSpec dimenProviderClass = codeGenerator.generateDimensionProviderClass();
+        JavaFile dimenProviderJavaFile = builder(packageName, dimenProviderClass).build();
+        dimenProviderJavaFile.writeTo(processingEnv.getFiler());
+
+        TypeSpec colorProviderClass = codeGenerator.generateColorProviderClass();
+        JavaFile colorProviderJavaFile = builder(packageName, colorProviderClass).build();
+        colorProviderJavaFile.writeTo(processingEnv.getFiler());
+
+        TypeSpec drawableProviderClass = codeGenerator.generateDrawableProviderClass();
+        JavaFile drawableProviderJavaFile = builder(packageName, drawableProviderClass).build();
+        drawableProviderJavaFile.writeTo(processingEnv.getFiler());
+
+        TypeSpec integerProviderClass = codeGenerator.generateIntegerProviderClass();
+        JavaFile integerProviderJavaFile = builder(packageName, integerProviderClass).build();
+        integerProviderJavaFile.writeTo(processingEnv.getFiler());
+
+        TypeSpec resourceProviderClass = codeGenerator.generateResourceProviderClass();
+        JavaFile resourceProviderJavaFile = builder(packageName, resourceProviderClass).build();
+        resourceProviderJavaFile.writeTo(processingEnv.getFiler());
     }
 }
 

--- a/sample/src/main/java/com/xfinity/resourceprovider/sample/MainPresenter.java
+++ b/sample/src/main/java/com/xfinity/resourceprovider/sample/MainPresenter.java
@@ -18,26 +18,26 @@ class MainPresenter {
     }
 
     void present() {
-        mainView.setFormattedText(resourceProvider.getOneArgFormattedString(FORMAT_ARG));
+        mainView.setFormattedText(resourceProvider.string.getOneArgFormattedString(FORMAT_ARG));
 
         Calendar today = Calendar.getInstance();
         if (today.get(Calendar.DAY_OF_MONTH) > MONTH_HALFWAY_POINT) {
-            mainView.setDateString(resourceProvider.getSecondHalfOfMonth());
+            mainView.setDateString(resourceProvider.string.getSecondHalfOfMonth());
         } else {
-            mainView.setDateString(resourceProvider.getFirstHalfOfMonth());
+            mainView.setDateString(resourceProvider.string.getFirstHalfOfMonth());
         }
 
         int dayOfWeek = today.get(Calendar.DAY_OF_WEEK);
         int daysUntilFriday = Calendar.FRIDAY - dayOfWeek;
         if (daysUntilFriday >= 0) {
-            mainView.setPluralsString(resourceProvider.getDaysUntilFridayQuantityString(daysUntilFriday, daysUntilFriday));
+            mainView.setPluralsString(resourceProvider.string.getDaysUntilFridayQuantityString(daysUntilFriday, daysUntilFriday));
         } else {
-            mainView.setPluralsString(resourceProvider.getSaturday());
+            mainView.setPluralsString(resourceProvider.string.getSaturday());
         }
 
-        mainView.setDrawable(resourceProvider.getIcnNavDino());
-        mainView.setDimenText("The Test Dimen is " + resourceProvider.getTestDimenPixelSize() + " in pixels");
-        mainView.setIntegerText("The Test Integer is " + resourceProvider.getTestInteger());
-        mainView.setColorViewBackgroundColor(resourceProvider.getBabyBlue());
+        mainView.setDrawable(resourceProvider.drawable.getIcnNavDino());
+        mainView.setDimenText("The Test Dimen is " + resourceProvider.dimen.getTestDimenPixelSize() + " in pixels");
+        mainView.setIntegerText("The Test Integer is " + resourceProvider.integer.getTestInteger());
+        mainView.setColorViewBackgroundColor(resourceProvider.color.getBabyBlue());
     }
 }


### PR DESCRIPTION
Currently, the ResourceProvider class won't compile if there
are two id that have duplicate names, e.g.
R.color.red and R.drawable.red.

To fix this, there are now delegate providers for each resource
type. To get strings, for instance, in this version, clients will call
resourceProvider.string.getStringResource()