### PR TITLE
Adjust how test utils are generated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
     }
 
     group = 'com.xfinity'
-    version = '1.0'
+    version = '1.0.1'
 }
 
 ext {
@@ -26,6 +26,6 @@ ext {
     artifactPrefix = 'resourceprovider'
     groupId = 'com.xfinity'
     uploadName = 'Resource-Provider'
-    publishVersion = '1.0'
+    publishVersion = '1.0.1'
     description = 'Utility for Auto-Generating an Android-Agnostic Resource Provider API'
 }

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -32,6 +32,8 @@ signing {
     sign configurations.archives
 }
 
+project.archivesBaseName = "$rootProject.artifactPrefix-compiler"
+
 uploadArchives {
     repositories {
         mavenDeployer {

--- a/compiler/src/main/java/com/xfinity/resourceprovider/RpKtCodeGenerator.kt
+++ b/compiler/src/main/java/com/xfinity/resourceprovider/RpKtCodeGenerator.kt
@@ -81,6 +81,6 @@ class RpKtCodeGenerator {
         val kotlinFile = kotlinFileBuilder.build()
 
         val kaptKotlinGeneratedDir = processingEnv.options["kapt.kotlin.generated"]
-        kotlinFile.writeTo(File(kaptKotlinGeneratedDir, "${kotlinFile.name}.kt"))
+        kotlinFile.writeTo(File(kaptKotlinGeneratedDir))
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,6 +25,8 @@ signing {
     sign configurations.archives
 }
 
+project.archivesBaseName = "$rootProject.artifactPrefix-library"
+
 uploadArchives {
     repositories {
         mavenDeployer {

--- a/library/src/main/java/com/xfinity/resourceprovider/RpTest.java
+++ b/library/src/main/java/com/xfinity/resourceprovider/RpTest.java
@@ -1,0 +1,10 @@
+package com.xfinity.resourceprovider;
+
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+
+@Target(value = FIELD)
+public @interface RpTest {
+    boolean generateIdProvider() default true;
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,20 +19,6 @@ android {
         versionName rootProject.publishVersion
     }
 
-    sourceSets {
-        testDebug {
-            java {
-                srcDir "${buildDir.absolutePath}/generated/source/kaptKotlin/debug"
-            }
-        }
-
-        testRelease {
-            java {
-                srcDir "${buildDir.absolutePath}/generated/source/kaptKotlin/release"
-            }
-        }
-    }
-
     lintOptions {
         disable 'InvalidPackage'
     }
@@ -45,12 +31,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     compile project(':library')
-    compile project(':testutils')
+
     kapt project(':compiler')
 
     testCompile 'junit:junit:4.12',
                 'org.mockito:mockito-core:2.7.21',
-                project(':testutils')
+                project(':testutils'),
+                project(':library')
 
     testImplementation('com.nhaarman:mockito-kotlin:1.4.0',
                        {

--- a/sample/src/test/java/com/xfinity/resourceprovider/sample/MainPresenterTest.kt
+++ b/sample/src/test/java/com/xfinity/resourceprovider/sample/MainPresenterTest.kt
@@ -1,5 +1,6 @@
 package com.xfinity.resourceprovider.sample
 
+import com.xfinity.resourceprovider.RpTest
 import com.xfinity.resourceprovider.testutils.mock
 import org.junit.Before
 import org.junit.Test
@@ -13,7 +14,7 @@ import java.util.Calendar
 @RunWith(MockitoJUnitRunner.Silent::class)
 class MainPresenterTest {
     @Mock private lateinit var mainView: MainView
-    @Mock private lateinit var resourceProvider: ResourceProvider
+    @Mock @RpTest private lateinit var resourceProvider: ResourceProvider
     private lateinit var presenter: MainPresenter
 
     @Before
@@ -47,7 +48,6 @@ class MainPresenterTest {
         verify<MainView>(mainView)
                 .setIdText("The Id TextView id is " + resourceProvider.ids.idTextId)
     }
-
 
     @Test
     fun date_presents_correctly() {

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-
 android {
     compileSdkVersion 28
 
@@ -59,6 +58,7 @@ signing {
     sign configurations.archives
 }
 
+project.archivesBaseName = "$rootProject.artifactPrefix-testutils"
 
 uploadArchives {
     repositories {

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'maven'
+apply plugin: 'signing'
+
 
 android {
     compileSdkVersion 28
@@ -35,4 +38,67 @@ dependencies {
 
 repositories {
     mavenCentral()
+}
+
+task sourceJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier "source"
+}
+
+//Creating sources with comments
+task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+signing {
+    sign configurations.archives
+}
+
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+
+            pom.project {
+                groupId rootProject.groupId
+                name "$rootProject.projectName Test Utils"
+                version rootProject.publishVersion
+                packaging 'aar'
+                description 'Test Utitlities for Resource Provider, an MVP Resources API for Android'
+                artifactId "$rootProject.artifactPrefix-testutils"
+                url 'https://github.com/Comcast/resourceprovider'
+
+                scm {
+                    url 'scm:git@github.com:Comcast/resourceprovider.git'
+                    connection 'scm:git@github.com:Comcast/resourceprovider.git'
+                    developerConnection 'scm:git@github.com:Comcast/resourceprovider.git'
+                }
+
+                licenses {
+                    license {
+                        name 'The Apache Software License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'dapp'
+                        name 'Mark Dappollone'
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
As of this commit, you no longer need to compile testutils
into your application, only your tests.  Also, you no longer
need to explicitly include the sourceSets in the test variants,
since the generated test utilities now output to the right location.