### PR TITLE
support for AndroidX

### DIFF
--- a/compiler/src/main/java/com/xfinity/resourceprovider/RpCodeGenerator.java
+++ b/compiler/src/main/java/com/xfinity/resourceprovider/RpCodeGenerator.java
@@ -35,7 +35,7 @@ final class RpCodeGenerator {
     private final AnnotationSpec suppressLint = AnnotationSpec.builder(ClassName.get("android.annotation", "SuppressLint"))
                                                .addMember("value", "$L", "{\"StringFormatInvalid\", \"StringFormatMatches\"}")
                                                .build();
-    private TypeName contextCompatClassName = get("android.support.v4.content", "ContextCompat");
+    private TypeName contextCompatClassName = get("androidx.core.content", "ContextCompat");
 
     RpCodeGenerator(String packageName, List<String> rClassStringVars, List<String> rClassPluralVars, List<String> rClassDrawableVars,
                     List<String> rClassDimenVars, List<String> rClassIntegerVars, List<String> rClassColorVars,

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@
 
 sonatypeUsername=your_un
 sonatypePassword=your_pw
+android.useAndroidX=true
+android.enableJetifier=true

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0-alpha02'
     implementation 'com.jakewharton:butterknife:8.7.0'
     implementation 'com.nhaarman:mockito-kotlin:1.6.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha02'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'com.jakewharton:butterknife:8.7.0'
     implementation 'com.nhaarman:mockito-kotlin:1.6.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/sample/src/main/java/com/xfinity/resourceprovider/sample/MainActivity.java
+++ b/sample/src/main/java/com/xfinity/resourceprovider/sample/MainActivity.java
@@ -2,7 +2,7 @@ package com.xfinity.resourceprovider.sample;
 
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -12,7 +12,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -29,7 +29,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar']),
-                   'com.android.support:appcompat-v7:27.1.1',
+            'androidx.appcompat:appcompat:1.0.0-beta01',
                    'org.mockito:mockito-core:2.7.21'
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -29,7 +29,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar']),
-            'androidx.appcompat:appcompat:1.0.0-beta01',
+            'androidx.appcompat:appcompat:1.0.0',
                    'org.mockito:mockito-core:2.7.21'
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"


### PR DESCRIPTION
Building a AndroidX projects with the resourceprovider incuded ends up with multiple errors: 'error: package android.support.v4.content does not exist'.
After performing androidX migration with the little change inside the RpCodeGenerator the problem seems to be solved